### PR TITLE
preserve symlinks in zip archive

### DIFF
--- a/lib/carthage_cache/archiver.rb
+++ b/lib/carthage_cache/archiver.rb
@@ -12,7 +12,7 @@ module CarthageCache
       files = Dir.entries(archive_path).select { |x| !x.start_with?(".") }
       files = files.select(&filter_block) if filter_block
       files = files.sort_by(&:downcase)
-      executor.execute("cd #{archive_path} && zip -r -X #{File.expand_path(destination_path)} #{files.join(' ')} > /dev/null")
+      executor.execute("cd #{archive_path} && zip -r -X -y #{File.expand_path(destination_path)} #{files.join(' ')} > /dev/null")
     end
 
     def unarchive(archive_path, destination_path)

--- a/spec/carthage_cache/archiver_spec.rb
+++ b/spec/carthage_cache/archiver_spec.rb
@@ -19,7 +19,7 @@ describe CarthageCache::Archiver do
   describe "#archive" do
 
     it "creates a zip file with the content of the project's 'Carthage/Build' directory" do
-      expected_command = "cd #{build_directory} && zip -r -X #{archive_path} CarthageCache.lock iOS Mac tvOS watchOS > /dev/null"
+      expected_command = "cd #{build_directory} && zip -r -X -y #{archive_path} CarthageCache.lock iOS Mac tvOS watchOS > /dev/null"
       expect(executor).to receive(:execute).with(expected_command)
       archiver.archive(build_directory, archive_path)
     end
@@ -27,7 +27,7 @@ describe CarthageCache::Archiver do
     context "when a filter block is passed" do
 
       it "filters platforms that don't match the filter" do
-        expected_command = "cd #{build_directory} && zip -r -X #{archive_path} CarthageCache.lock iOS > /dev/null"
+        expected_command = "cd #{build_directory} && zip -r -X -y #{archive_path} CarthageCache.lock iOS > /dev/null"
         expect(executor).to receive(:execute).with(expected_command)
         archiver.archive(build_directory, archive_path) do |x|
           x == CarthageCache::CarthageCacheLock::LOCK_FILE_NAME || x == "iOS"


### PR DESCRIPTION
What:
preserve symlinks in zip archive to prevent error during signature validation in Xcode 15 caused by replacing symlinks in frameworks with real files