### PR TITLE
[platform] Include xcodebuild version in the cache value

### DIFF
--- a/lib/carthage_cache/carthage_resolved_file.rb
+++ b/lib/carthage_cache/carthage_resolved_file.rb
@@ -12,7 +12,6 @@ module CarthageCache
       @file_path = file_path
       @swift_version_resolver = swift_version_resolver
       @terminal = terminal
-
     end
 
     def digest


### PR DESCRIPTION
Seems like Swift version updates as part of every xcodebuild version but that's not always true.